### PR TITLE
tags even if number of approvals > required

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,7 @@ label_when_approved() {
 
     echo "${approvals}/${APPROVALS} approvals"
 
-    if [[ "$approvals" == "$APPROVALS" ]]; then
+    if [[ "$approvals" -ge "$APPROVALS" ]]; then
       echo "Labeling pull request"
 
       curl -sSL \


### PR DESCRIPTION
Not sure if it can append but if there is more approval than required and it's not yet tagged, it may skip it instead of tagging it

What do you think ?